### PR TITLE
Added device_get_fn_turn_status command that executes FF40h call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ nytprof.out
 *.o
 *.bs
 /_eumm/
+.idea/
+._DS_Store
+*~

--- a/interface.txt
+++ b/interface.txt
@@ -1156,6 +1156,11 @@ call:   device_get_fn_version
 params: password, int32
 return: dict["string", "string"]
 
+command: 0xFF40
+call:   device_get_fn_turn_status
+params: password, int32
+return: dict["string", "string"]
+
 command: 0xFF41
 call:   device_set_start_open_turn
 params: password, int32

--- a/lib/CashRegister/ShtrihFR.pm
+++ b/lib/CashRegister/ShtrihFR.pm
@@ -18,7 +18,7 @@ use strict;
 
 use constant
 {
-    MY_DRIVER_VERSION => 20170929,
+    MY_DRIVER_VERSION => 20190514,
     FR_PROTOCOL_VERSION	=> 1.99
 };
 
@@ -169,6 +169,7 @@ use constant
     FF_GET_FN_NUMBER		=> 0x02,
     FF_GET_FN_DURATION		=> 0x03,
     FF_GET_FN_VERSION		=> 0x04,
+    FF_GET_FN_TURN_STATUS  	=> 0x40,
     FF_SET_START_OPEN_TURN	=> 0x41,
     FF_SET_START_CLOSE_TURN	=> 0x42
 };
@@ -3340,6 +3341,29 @@ sub get_fn_version
 	$res->{FN_VERSION} = Encode::decode($self->{ENCODE_TO}, $version);
 	$res->{FN_TYPE} = get_hexstr2($type);
     }
+
+    return $res;
+}
+
+sub get_fn_turn_status
+{
+    my ($self, $pass, undef) = @_;
+
+    my $res = {};
+    my $buf = $self->send_cmd_ff(6, FF_GET_FN_TURN_STATUS, "V", $pass);
+
+
+    if($buf) {
+        my ($tour_state, $tour_number, $receipt_number, undef) = unpack("Cvv", $buf);
+
+        $res->{TOUR_STATE} = $tour_state;
+        $res->{TOUR_NUMBER} = $tour_number;
+        $res->{RECEIPT_NUMBER} = $receipt_number;
+    }
+
+    $res->{DRIVER_VERSION} = MY_DRIVER_VERSION;
+    $res->{ERROR_CODE} = $self->{ERROR_CODE};
+    $res->{ERROR_MESSAGE} = $self->{ERROR_MESSAGE};
 
     return $res;
 }

--- a/shtrih_fr.service
+++ b/shtrih_fr.service
@@ -294,6 +294,7 @@ dbus_method("device_get_fn_status", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_get_fn_number", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_get_fn_duration", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_get_fn_version", ["int32"], [["dict", "string", "string"]]);
+dbus_method("device_get_fn_turn_status", ["int32"], [["dict", "string", "string"]]);
 
 dbus_method("device_set_start_open_turn", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_set_start_close_turn", ["int32"], [["dict", "string", "string"]]);
@@ -1880,6 +1881,18 @@ sub device_get_fn_version
 
     return $self->device_is_online() ?
 	$self->{DEVICE}->get_fn_version(@_) : { ERROR_CODE => -1, ERROR_MESSAGE => $self->device_get_error() };
+}
+
+
+sub device_get_fn_turn_status
+{
+    my $self = shift;
+
+    my ($package, $filename, $line, $subroutine, undef) = caller(0);
+    $self->syslog("debug", $subroutine, ", params: [" . join(",", @_) . "]");
+
+    return $self->device_is_online() ?
+        $self->{DEVICE}->get_fn_turn_status(@_) : { ERROR_CODE => -1, ERROR_MESSAGE => $self->device_get_error() };
 }
 
 sub device_set_start_open_turn


### PR DESCRIPTION
Added missing function device_get_fn_turn_status: required to obtain receipt number.