### PR TITLE
Added get_fn_fiscalization_result

### DIFF
--- a/interface.txt
+++ b/interface.txt
@@ -1156,6 +1156,12 @@ call:   device_get_fn_version
 params: password, int32
 return: dict["string", "string"]
 
+
+command: 0xFF09
+call:   device_get_fn_fiscalization_result
+params: password, int32
+return: dict["string", "string"]
+
 command: 0xFF40
 call:   device_get_fn_turn_status
 params: password, int32

--- a/lib/CashRegister/ShtrihFR.pm
+++ b/lib/CashRegister/ShtrihFR.pm
@@ -169,6 +169,7 @@ use constant
     FF_GET_FN_NUMBER        => 0x02,
     FF_GET_FN_DURATION      => 0x03,
     FF_GET_FN_VERSION       => 0x04,
+    FF_GET_FN_FISCALIZATION_RESULT => 0x09,
     FF_GET_FN_TURN_STATUS   => 0x40,
     FF_SET_START_OPEN_TURN  => 0x41,
     FF_SET_START_CLOSE_TURN => 0x42,
@@ -3350,6 +3351,29 @@ sub get_fn_version
 
     return $res;
 }
+
+sub get_fn_fiscalization_result
+{
+    my ($self, $pass, undef) = @_;
+
+    my $res = {};
+    my $buf = $self->send_cmd_ff(6, FF_GET_FN_FISCALIZATION_RESULT, "V", $pass);
+
+    $res->{DRIVER_VERSION} = MY_DRIVER_VERSION;
+    $res->{ERROR_CODE} = $self->{ERROR_CODE};
+    $res->{ERROR_MESSAGE} = $self->{ERROR_MESSAGE};
+
+    if($buf)
+    {
+        # TODO: retrieves KKT RN only. Modify this if you need anything else
+        my ($year, $month, $day, $hour, $minute, $inn, $kkt_rn, undef) = unpack("CCCCCa12a20", $buf);
+
+        $res->{KKT_RN} = $kkt_rn;
+    }
+
+    return $res;
+}
+
 
 sub get_fn_turn_status
 {

--- a/shtrih_fr.service
+++ b/shtrih_fr.service
@@ -296,6 +296,7 @@ dbus_method("device_get_fn_duration", ["int32"], [["dict", "string", "string"]])
 dbus_method("device_get_fn_version", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_get_fn_turn_status", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_get_find_fn_document", ["int32", "int32"], [["dict", "string", "string"]]);
+dbus_method("device_get_fn_fiscalization_result", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_set_start_open_turn", ["int32"], [["dict", "string", "string"]]);
 dbus_method("device_set_start_close_turn", ["int32"], [["dict", "string", "string"]]);
 
@@ -1904,6 +1905,17 @@ sub device_get_find_fn_document
 
     return $self->device_is_online() ?
 	$self->{DEVICE}->get_find_fn_document(@_) : { ERROR_CODE => -1, ERROR_MESSAGE => $self->device_get_error() };
+}
+
+sub device_get_fn_fiscalization_result
+{
+    my $self = shift;
+
+    my ($package, $filename, $line, $subroutine, undef) = caller(0);
+    $self->syslog("debug", $subroutine, ", params: [" . join(",", @_) . "]");
+
+    return $self->device_is_online() ?
+	$self->{DEVICE}->get_fn_fiscalization_result(@_) : { ERROR_CODE => -1, ERROR_MESSAGE => $self->device_get_error() };
 }
 
 sub device_set_start_open_turn


### PR DESCRIPTION
Added get_fn_fiscalization_result method to retrieve KKT RN (KKT registration number). Only KKT_RN parameter is retrieved - other parameters are ignored.